### PR TITLE
Straighten out the logging story.

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -20,6 +20,7 @@ Sparky.task('default', ['copy-html'], () => {
     homeDir: 'src',
     output: `${OUTPUT_DIR}/$name.js`,
     target: 'electron',
+    log: isProduction,
     cache: !isProduction,
     sourceMaps: true
   })

--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
     "postinstall": "Used by electron-builder to build native dependencies.",
     "start": "Starts the app in dev mode."
   },
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,8 +3,10 @@ import { createWindow } from './create-window'
 import * as log from 'electron-log'
 import * as isDev from 'electron-is-dev'
 import { setupAutoUpdates } from './auto-updater'
+
 // set proper logging level
-log.transports.file.level = isDev ? 'error' : 'debug'
+log.transports.file.level = isDev ? false : 'info'
+log.transports.console.level = isDev ? 'debug' : false
 
 // usually we'd just use __dirname here, however, the FuseBox
 // bundler rewrites that, so we have to get it from Electron.

--- a/src/renderer/app/app.tsx
+++ b/src/renderer/app/app.tsx
@@ -1,6 +1,6 @@
-
 import * as React from 'react'
 import { Text, Logo, FunDog } from '../platform'
+// import * as log from 'electron-log'
 
 const appStyle = {
   flex: 1,
@@ -25,6 +25,15 @@ const textStyle = {
 }
 
 export class App extends React.Component<{}, {}> {
+
+  componentWillMount () {
+    // log.debug('example of logging')
+  }
+
+  componentDidMount () {
+    // log.info('more logging')
+  }
+
   render() {
     return (
       <div style={appStyle}>


### PR DESCRIPTION
* log to the console in dev, but a file in production.
* don't show the noise of bundling in dev, just while we're packaging.
* include some examples of how to do logging
