### PR TITLE
Added nsis on windows so the latest.yml gets created.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     },
     "win": {
       "target": [
-        "zip"
+        "zip",
+        "nsis"
       ]
     }
   },
@@ -92,5 +93,5 @@
     "postinstall": "Used by electron-builder to build native dependencies.",
     "start": "Starts the app in dev mode."
   },
-  "version": "0.7.0"
+  "version": "0.7.1"
 }


### PR DESCRIPTION
Kinda goofy that I have to do this, but the `latest.yml` for auto-updating isn't generated unless we build an `nsis` version.

I guess that makes sense.  The straight-up compressed folder deploys aren't expected to update?

Ok, ya, that makes no sense.

I didn't see a way to force the `latest.yml` to generate, but I didn't look that hard.