### PR TITLE
Inline Storybook + Storybook-focus components

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,17 +2,17 @@ const path = require('path')
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js')
 
 module.exports = (config, env) => {
-    const myConfig = genDefaultConfig(config, env)
+  const myConfig = genDefaultConfig(config, env)
 
-    myConfig.module.rules.push({
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        exclude: /node_modules/,
-        include: path.resolve(__dirname, '..', 'src')
-    })
+  myConfig.module.rules.push({
+    test: /\.tsx?$/,
+    loader: 'ts-loader',
+    exclude: /node_modules/,
+    include: path.resolve(__dirname, '..', 'src'),
+  })
 
-    myConfig.resolve.extensions.unshift('.tsx')
-    myConfig.resolve.extensions.unshift('.ts')
+  myConfig.resolve.extensions.unshift('.tsx')
+  myConfig.resolve.extensions.unshift('.ts')
 
-    return myConfig
+  return myConfig
 }

--- a/fuse.ts
+++ b/fuse.ts
@@ -43,7 +43,7 @@ Sparky.task('default', ['copy-html'], () => {
     .bundle('renderer')
     .instructions('> [renderer/index.tsx] +fuse-box-css')
     .plugin(CSSPlugin())
-    .plugin(CopyPlugin({ useDefault: true, files: ASSETS, dest: 'assets', resolve: 'assets/' }))
+    .plugin(CopyPlugin({ useDefault: false, files: ASSETS, dest: 'assets', resolve: 'assets/' }))
 
   // and watch & hot reload unless we're bundling for production
   if (!isProduction) {

--- a/src/main/main-window/load-url.ts
+++ b/src/main/main-window/load-url.ts
@@ -1,0 +1,20 @@
+import { join } from 'path'
+import { format } from 'url'
+
+export function loadURL(
+  window: Electron.BrowserWindow,
+  appPath: string,
+  showStorybook: boolean = false,
+) {
+  if (showStorybook) {
+    window.loadURL('http://localhost:6006')
+  } else {
+    window.loadURL(
+      format({
+        pathname: join(appPath, 'out/index.html'),
+        protocol: 'file:',
+        slashes: true,
+      }),
+    )
+  }
+}

--- a/src/main/main-window/main-window.ts
+++ b/src/main/main-window/main-window.ts
@@ -1,7 +1,6 @@
 import { app, BrowserWindow } from 'electron'
-import { join } from 'path'
-import { format } from 'url'
 import WindowStateManager = require('electron-window-state-manager')
+import { loadURL } from './load-url'
 
 // default dimensions
 const DIMENSIONS = { width: 600, height: 500, minWidth: 450, minHeight: 450 }
@@ -52,13 +51,7 @@ export function createMainWindow(appPath: string) {
   window.on('resize', () => windowState.saveState(window))
 
   // load entry html page in the renderer.
-  window.loadURL(
-    format({
-      pathname: join(appPath, 'out/index.html'),
-      protocol: 'file:',
-      slashes: true,
-    }),
-  )
+  loadURL(window, appPath)
 
   // only appear once we've loaded
   window.webContents.on('did-finish-load', () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,6 @@
-import { app } from 'electron'
+import { app, ipcMain } from 'electron'
 import { createMainWindow } from './main-window/main-window'
+import { loadURL } from './main-window/load-url'
 import * as log from 'electron-log'
 import * as isDev from 'electron-is-dev'
 import { createUpdater } from './updater/updater'
@@ -9,14 +10,25 @@ import { createMenu } from './menu/menu'
 log.transports.file.level = isDev ? false : 'info'
 log.transports.console.level = isDev ? 'debug' : false
 
+let window: Electron.BrowserWindow
+let showStorybook = false
+
 // usually we'd just use __dirname here, however, the FuseBox
 // bundler rewrites that, so we have to get it from Electron.
 const appPath = app.getAppPath()
 
 // fires when Electron is ready to start
 app.on('ready', () => {
-  const window = createMainWindow(appPath)
+  window = createMainWindow(appPath)
   createMenu(window)
+
+  if (isDev) {
+    ipcMain.on('storybook-toggle', () => {
+      log.info('toggle')
+      showStorybook = !showStorybook
+      loadURL(window, appPath, showStorybook)
+    })
+  }
 })
 
 // fires when all windows are closed

--- a/src/main/menu/linux-menu.ts
+++ b/src/main/menu/linux-menu.ts
@@ -16,6 +16,7 @@ export function createLinuxMenu(
     submenu: isDev
       ? [
           { ...shared.reload, accelerator: 'Ctrl+R' },
+          { ...shared.storybook, accelerator: 'Ctrl+Shift+S' },
           { ...shared.toggleDevTools, accelerator: 'Ctrl+Alt+I' },
       ]
       : [{ ...shared.fullScreen, accelerator: 'Ctrl+Alt+F' }],

--- a/src/main/menu/macos-menu.ts
+++ b/src/main/menu/macos-menu.ts
@@ -26,6 +26,7 @@ export function createMacMenu(
     submenu: isDev
       ? [
           { ...shared.reload, accelerator: 'Command+R' },
+          { ...shared.storybook, accelerator: 'Command+Shift+S' },
           { ...shared.toggleDevTools, accelerator: 'Alt+Command+I' },
       ]
       : [{ ...shared.fullScreen, accelerator: 'Ctrl+Command+F' }],

--- a/src/main/menu/shared-menu.ts
+++ b/src/main/menu/shared-menu.ts
@@ -1,4 +1,5 @@
-import { shell } from 'electron'
+import * as log from 'electron-log'
+import { shell, ipcMain } from 'electron'
 
 export function createSharedMenuItems(window: Electron.BrowserWindow) {
   const visit: Electron.MenuItemConstructorOptions = {
@@ -12,6 +13,14 @@ export function createSharedMenuItems(window: Electron.BrowserWindow) {
     label: 'Reload',
     click() {
       window.webContents.reload()
+    },
+  }
+
+  const storybook: Electron.MenuItemConstructorOptions = {
+    label: 'Toggle Storybook',
+    click() {
+      log.info('gonna send')
+      ipcMain.emit('storybook-toggle')
     },
   }
 
@@ -34,6 +43,7 @@ export function createSharedMenuItems(window: Electron.BrowserWindow) {
   return {
     visit,
     reload,
+    storybook,
     quit,
     toggleDevTools,
     fullScreen,

--- a/src/main/menu/windows-menu.ts
+++ b/src/main/menu/windows-menu.ts
@@ -16,6 +16,7 @@ export function createWindowsMenu(
     submenu: isDev
       ? [
           { ...shared.reload, accelerator: 'Ctrl+R' },
+          { ...shared.storybook, accelerator: 'Ctrl+Shift+S' },
           { ...shared.toggleDevTools, accelerator: 'Ctrl+Alt+I' },
       ]
       : [{ ...shared.fullScreen, accelerator: 'Ctrl+Alt+F' }],

--- a/src/renderer/features/example-using-tabs/fun-dog/fun-dog.story.tsx
+++ b/src/renderer/features/example-using-tabs/fun-dog/fun-dog.story.tsx
@@ -1,6 +1,18 @@
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
+import {
+  StorybookStory as Story,
+  StorybookGroup as Group,
+} from '../../../platform/components/storybook'
 
-import { FunDog } from './index'
+import { FunDog } from './fun-dog'
 
-storiesOf('Fun Dog', module).add('default', () => <FunDog />)
+storiesOf('Fun Dog', module).add('default', () =>
+  <Story>
+    <Group title='is a doggo'>
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <FunDog />
+      </div>
+    </Group>
+  </Story>,
+)

--- a/src/renderer/features/example-using-tabs/fun-dog/fun-dog.tsx
+++ b/src/renderer/features/example-using-tabs/fun-dog/fun-dog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { CSSProperties } from 'react'
-import dogImage from './fun-dog.jpg'
+import * as dogImage from './fun-dog.jpg'
 import { colors, SpinAnimation } from '../../../platform'
 import { css } from 'glamor'
 

--- a/src/renderer/features/example-using-tabs/logo/logo.tsx
+++ b/src/renderer/features/example-using-tabs/logo/logo.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { CSSProperties } from 'react'
 import { cssProps, animations } from '../../../platform'
-import icon from './electron-icon.svg'
+import * as icon from './electron-icon.svg'
 import { css } from 'glamor'
 
 const ROOT = css(

--- a/src/renderer/platform/components/storybook/index.ts
+++ b/src/renderer/platform/components/storybook/index.ts
@@ -1,0 +1,3 @@
+export * from './storybook-label'
+export * from './storybook-group'
+export * from './storybook-story'

--- a/src/renderer/platform/components/storybook/storybook-group.tsx
+++ b/src/renderer/platform/components/storybook/storybook-group.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { CSSProperties } from 'react'
+import { StorybookLabel } from './storybook-label'
+
+export const StorybookGroup: React.StatelessComponent<{ title: string }> = props => {
+  const style: CSSProperties = {
+    paddingBottom: 20,
+  }
+  return (
+    <div style={style}>
+      <StorybookLabel title={props.title} />
+      {props.children}
+    </div>
+  )
+}

--- a/src/renderer/platform/components/storybook/storybook-label.tsx
+++ b/src/renderer/platform/components/storybook/storybook-label.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { CSSProperties } from 'react'
+
+const textStyle: CSSProperties = {
+  marginLeft: -20,
+  color: '#3d3d3d',
+  borderBottom: '1px solid #eee',
+  paddingBottom: 5,
+  marginBottom: 5,
+  fontFamily: 'Helvetica Neue',
+  fontSize: 14,
+}
+
+export const StorybookLabel: React.StatelessComponent<{ title: string }> = props =>
+  <p style={textStyle}>
+    {props.title}
+  </p>

--- a/src/renderer/platform/components/storybook/storybook-story.tsx
+++ b/src/renderer/platform/components/storybook/storybook-story.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+import { CSSProperties } from 'react'
+
+const style: CSSProperties = {
+  paddingLeft: 20,
+  paddingRight: 20,
+}
+
+export const StorybookStory: React.StatelessComponent<{}> = props =>
+  <div style={style}>
+    {props.children}
+  </div>

--- a/src/renderer/platform/components/text/text.story.tsx
+++ b/src/renderer/platform/components/text/text.story.tsx
@@ -1,10 +1,66 @@
 import * as React from 'react'
+import { StorybookStory as Story, StorybookGroup as Group } from '../storybook'
+
 import { storiesOf } from '@storybook/react'
 
 import { Text } from './index'
 
-storiesOf('Text', module).add('default', () => <Text>Hello World!</Text>).add('with children', () =>
-  <Text>
-    <strong>I am STRONG</strong>
-  </Text>,
-)
+storiesOf('Text', module)
+  .add('text styles', () =>
+    <Story>
+      <Group title='regular text'>
+        <Text>Hello World!</Text>
+        <Text>$123.45</Text>
+        <Text>The quick brown fox jumped over the slow lazy dog.</Text>
+      </Group>
+      <Group title='huge paragraph'>
+        <Text>
+          Wayfarers intelligentsia salvia sartorial keffiyeh locavore direct trade flexitarian
+          vexillologist ugh single-origin coffee. Hexagon heirloom direct trade palo santo
+          distillery, PBR&B bespoke fanny pack adaptogen affogato bitters kombucha sartorial taiyaki
+          next level. Cliche artisan iPhone bushwick church-key. Artisan forage mustache, chartreuse
+          vexillologist echo park cronut. 8-bit fanny pack 90's post-ironic venmo vegan. Humblebrag
+          cliche pork belly, cronut twee wayfarers salvia meditation plaid cornhole. Tumeric
+          literally yr XOXO, ennui single-origin coffee blog jianbing jean shorts plaid typewriter
+          prism whatever pabst flannel. Tousled lomo next level pickled mixtape. Everyday carry
+          ennui polaroid chartreuse, biodiesel trust fund hashtag umami cardigan hot chicken
+          locavore gochujang quinoa coloring book williamsburg. Next level 8-bit cornhole brunch
+          venmo. Enamel pin normcore DIY jianbing irony thundercats. Taxidermy quinoa kinfolk,
+          hexagon godard hell of banjo forage ugh blog. Kale chips umami +1 shabby chic air plant
+          keffiyeh authentic whatever sriracha wayfarers letterpress tofu brooklyn next level
+          salvia. Selfies readymade vegan synth chillwave pug banjo dreamcatcher freegan. Artisan
+          cliche subway tile mumblecore, whatever pok pok tote bag celiac hella poke tousled
+          listicle. Deep v unicorn scenester cred direct trade kickstarter microdosing cardigan
+          mustache ennui tumblr umami farm-to-table literally listicle. Post-ironic semiotics venmo
+          gochujang cray green juice lo-fi cardigan tilde prism pop-up jean shorts shoreditch occupy
+          readymade. Portland messenger bag art party, succulents cred lyft bespoke. Kinfolk plaid
+          selfies pinterest iPhone pug narwhal, fashion axe coloring book meditation tousled. Lyft
+          trust fund copper mug DIY la croix banh mi. Jianbing raclette man bun mustache tote bag.
+          Vinyl taiyaki kombucha tattooed, try-hard blog freegan you probably haven't heard of them
+          schlitz shaman listicle chambray. Swag slow-carb enamel pin affogato migas bespoke fashion
+          axe flannel prism marfa activated charcoal pop-up shabby chic. Oh. You need a little dummy
+          text for your mockup? How quaint. I bet you’re still using Bootstrap too…
+        </Text>
+      </Group>
+      <Group title='style={{ color: &quot;red&quot; }}'>
+        <Text style={{ color: 'red' }}>Hello World!</Text>
+      </Group>
+    </Story>,
+  )
+  .add('with nested children', () =>
+    <Story>
+      <Group title='with nested children'>
+        <Text>
+          <p>
+            <strong>I am STRONG</strong>
+          </p>
+          <p>
+            <i>I am ITALIC</i>
+          </p>
+          <p>
+            <Text>I am another nested Text component.</Text>
+          </p>
+        </Text>
+      </Group>
+    </Story>,
+  )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "jsx": "react",
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "strict": true,
     "noUnusedLocals": true
   }

--- a/typings/images.d.ts
+++ b/typings/images.d.ts
@@ -1,21 +1,7 @@
 // Tell the TS compiler that it's ok to load these
-// types of extensions.  FuseBox will do the right thing.
-declare module '*.jpeg' {
-  export default ''
-}
-
-declare module '*.jpg' {
-  export default ''
-}
-
-declare module '*.gif' {
-  export default ''
-}
-
-declare module '*.png' {
-  export default ''
-}
-
-declare module '*.svg' {
-  export default ''
-}
+// types of extensions.  FuseBox and webpack will do the right thing.
+declare module '*.jpeg'
+declare module '*.jpg'
+declare module '*.gif'
+declare module '*.png'
+declare module '*.svg'


### PR DESCRIPTION
Rich,

### Inline?  Yes plz.

![inline-storybook](https://user-images.githubusercontent.com/68273/29254473-e0f915de-8063-11e7-9aa4-ab6529b9d152.gif)

### Storybook-specific components

I created a couple of small components for use within Storybooks.  

```jsx
import { StorybookGroup as Group, StorybookStory as Story } from '........'

<Story>
  <Group title='some title' />
  <Text>Welcome to `test.story.tsx`</Text>

  <Group title='some title' />
  <Text>Also, this kinda works.</Text>
</Story>
```




### Image Shenanigans

Also had to do a little dance with the `image` support to make it work.  

Tried a bunch of things to continue to make `import dogImage from './fun-dog.jpg'` compatible with both `webpack` and `fuse-box`.  switching to `import * as dogImage from './fun-dog.jpg'` is the closest I could come.

Womp womp.
